### PR TITLE
JT-5 Implement Database Schema and Migration Scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 */node_modules
+*/.env

--- a/server/.env-example
+++ b/server/.env-example
@@ -1,0 +1,4 @@
+MYSQL_HOST="127.0.0.1"
+MYSQL_USER="root"
+MYSQL_PASSWORD=""
+MYSQL_DB="job_tracker"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^4.19.2"
+        "dotenv": "^16.4.5",
+        "express": "^4.19.2",
+        "fs-extra": "^11.2.0",
+        "mysql2": "^3.10.2",
+        "path": "^0.12.7"
       }
     },
     "node_modules/accepts": {
@@ -145,6 +149,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -162,6 +175,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ee-first": {
@@ -293,6 +318,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -300,6 +338,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
       }
     },
     "node_modules/get-intrinsic": {
@@ -332,6 +379,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
@@ -424,6 +476,38 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -487,6 +571,58 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/mysql2": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.2.tgz",
+      "integrity": "sha512-KCXPEvAkO0RcHPr362O5N8tFY2fXvbjfkPvRY/wGumh4EOemo9Hm5FjQZqv/pCmrnuxGu5OxnSENG0gTXqKMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru-cache": "^8.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/mysql2/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/named-placeholders/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -529,11 +665,28 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "license": "MIT"
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -643,6 +796,11 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
     "node_modules/serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
@@ -699,6 +857,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -730,6 +897,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -738,6 +913,19 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -5,13 +5,18 @@
   "scripts": {
     "server": "npm run prebuild && npm start",
     "start": "node index.js",
-    "prebuild": "cd .. && cd client && npm install && npm run build"
+    "prebuild": "cd .. && cd client && npm install && npm run build",
+    "create-db": "node run-schema.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "express": "^4.19.2"
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "fs-extra": "^11.2.0",
+    "mysql2": "^3.10.2",
+    "path": "^0.12.7"
   }
 }

--- a/server/run-schema.js
+++ b/server/run-schema.js
@@ -1,0 +1,70 @@
+const fs = require("fs-extra");
+const path = require("path");
+const mysql = require("mysql2");
+const dotenv = require("dotenv");
+dotenv.config();
+
+// Read SQL file
+const schemaPath = path.join(__dirname, "schema.sql");
+const schemaSQL = fs.readFileSync(schemaPath, "utf-8");
+
+// SQL Statements
+const sqlStatements = schemaSQL.split(";").map(statement => statement.trim()).filter(statement => statement.length > 0);
+
+// Create SQL connection
+const pool = mysql.createPool({
+    host: process.env.MYSQL_HOST,
+    user: process.env.MYSQL_USER,
+    password: process.env.MYSQL_PASSWORD,
+    // database: process.env.MYSQL_DB,
+    waitForConnections: true,
+    multipleStatements: true,
+    connectionLimit: 10,
+    queueLimit: 0,
+});
+
+// Function for executing one sql statement
+const executeSQL = (connection, statement) => {
+    return new Promise((resolve, reject) => {
+        connection.query(statement, (err) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve();
+            }
+        });
+    });
+}
+
+// Connect to SQL server
+pool.getConnection((err, connection) => {
+    if (err) {
+        console.error("Error connecting to database: ", err);
+        return;
+    }
+
+    console.log("Connected to the database");
+
+    // Execute each SQL statement
+    let promise = Promise.resolve();
+    sqlStatements.forEach(statement => {
+        promise = promise.then(() => {
+            return executeSQL(connection, statement);
+        }).then(() => {
+            console.log("SQL statement executed successfully: ", statement);
+        }).catch((err) => {
+            console.error("Error executing SQL statement: ", statement);
+            throw err;
+        });
+    });
+
+    promise.then(() => {
+        connection.release();
+        console.log("SQL schema executed successfully");
+    }).catch(() => {
+        connection.release();
+        console.error("Error executing schema");
+    }).finally(() => {
+        pool.end();
+    });
+});

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -1,3 +1,4 @@
+# DB SETUP
 DROP DATABASE IF EXISTS job_tracker;
 CREATE DATABASE job_tracker;
 USE job_tracker;
@@ -103,6 +104,7 @@ INSERT INTO `status` (
     'Interested'
 );
 
+# Add demo data
 INSERT INTO user (
     first_name,
     last_name,
@@ -113,4 +115,76 @@ INSERT INTO user (
     'User',
     'testuser',
     'password'
+);
+INSERT INTO job (
+    title,
+    company,
+    salary,
+    location,
+    apply_date
+) VALUES (
+    'Software Engineer',
+    'Google',
+    100000,
+    'Mountain View, CA',
+    '2021-01-01'
+);
+INSERT INTO progress (
+    description,
+    date
+) VALUES (
+    'Applied',
+    '2021-01-01'
+);
+
+INSERT INTO skill (
+    name
+) VALUES (
+    'JavaScript'
+);
+INSERT INTO contact (
+    first_name,
+    last_name,
+    email,
+    phone_number
+) VALUES (
+    'John',
+    'Doe',
+    'john@google.com',
+    '1234567890'
+);
+INSERT INTO job_status (
+    job_id,
+    status_id
+) VALUES (
+    1,
+    1
+);
+INSERT INTO job_progress (
+    job_id,
+    progress_id
+) VALUES (
+    1,
+    1
+);
+INSERT INTO job_skill (
+    job_id,
+    skill_id
+) VALUES (
+    1,
+    1
+);
+INSERT INTO job_contact (
+    job_id,
+    contact_id
+) VALUES (
+    1,
+    1
+);
+INSERT INTO user_job (
+    user_id,
+    job_id
+) VALUES (
+    1,
+    1
 );

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -1,0 +1,116 @@
+DROP DATABASE IF EXISTS job_tracker;
+CREATE DATABASE job_tracker;
+USE job_tracker;
+CREATE TABLE user (
+    id INT NOT NULL AUTO_INCREMENT,
+    first_name VARCHAR(255) NOT NULL,
+    last_name VARCHAR(255) NOT NULL,
+    username VARCHAR(255) NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    UNIQUE (username),
+    PRIMARY KEY (id)
+);
+CREATE TABLE job (
+    id INT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(255) NOT NULL,
+    company VARCHAR(255) NOT NULL,
+    salary DECIMAL(10, 2) NULL,
+    location VARCHAR(255) NOT NULL,
+    apply_date DATE NOT NULL,
+    PRIMARY KEY (id)
+);
+CREATE TABLE status (
+    id INT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+);
+CREATE TABLE progress (
+    id INT NOT NULL AUTO_INCREMENT,
+    description VARCHAR(255) NOT NULL,
+    date DATE NOT NULL,
+    PRIMARY KEY (id)
+);
+CREATE TABLE skill (
+    id INT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+);
+CREATE TABLE contact (
+    id INT NOT NULL AUTO_INCREMENT,
+    first_name VARCHAR(255) NOT NULL,
+    last_name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    phone_number VARCHAR(10) NOT NULL,
+    PRIMARY KEY (id)
+);
+CREATE TABLE job_status (
+    id INT NOT NULL AUTO_INCREMENT,
+    job_id INT NOT NULL, 
+    status_id INT NOT NULL, 
+    FOREIGN KEY (job_id) REFERENCES job(id),
+    FOREIGN KEY (status_id) REFERENCES status(id),
+    PRIMARY KEY (id)
+);
+CREATE TABLE job_progress (
+    id INT NOT NULL AUTO_INCREMENT,
+    job_id INT NOT NULL, 
+    progress_id INT NOT NULL, 
+    FOREIGN KEY (job_id) REFERENCES job(id),
+    FOREIGN KEY (progress_id) REFERENCES progress(id),
+    PRIMARY KEY (id)
+);
+CREATE TABLE job_skill (
+    id INT NOT NULL AUTO_INCREMENT,
+    job_id INT NOT NULL, 
+    skill_id INT NOT NULL, 
+    FOREIGN KEY (job_id) REFERENCES job(id),
+    FOREIGN KEY (skill_id) REFERENCES skill(id),
+    PRIMARY KEY (id)
+);
+CREATE TABLE job_contact (
+    id INT NOT NULL AUTO_INCREMENT,
+    job_id INT NOT NULL, 
+    contact_id INT NOT NULL, 
+    FOREIGN KEY (job_id) REFERENCES job(id),
+    FOREIGN KEY (contact_id) REFERENCES contact(id),
+    PRIMARY KEY (id)
+);
+CREATE TABLE user_job (
+    id INT NOT NULL AUTO_INCREMENT,
+    user_id INT NOT NULL, 
+    job_id INT NOT NULL, 
+    FOREIGN KEY (user_id) REFERENCES user(id),
+    FOREIGN KEY (job_id) REFERENCES job(id),
+    PRIMARY KEY (id)
+);
+INSERT INTO `status` (
+    `name`
+) VALUES (
+    'Applied'
+), (
+    'Interview Scheduled'
+), (
+    'Interviewed'
+), (
+    'Offer Extended'
+), (
+    'Offer Accepted'
+), (
+    'Offer Declined'
+), (
+    'Rejected'
+), (
+    'Interested'
+);
+
+INSERT INTO user (
+    first_name,
+    last_name,
+    username,
+    password
+) VALUES (
+    'Test',
+    'User',
+    'testuser',
+    'password'
+);


### PR DESCRIPTION
I added a script `npm run create-db` that will create your database with all the tables and a demo entry for each table. Use with caution because it will drop the existing job_tracker database before writing the demo one.

Also please note the .env-example file. These are all of the env variables being used currently. You'll need to create and configure your own .env file using .env-example as a template.

Lastly, there are a couple new packages, so when you pull the changes please run `npm install`